### PR TITLE
Added asset images to shadow drive 

### DIFF
--- a/app/api/actions/buy/const.ts
+++ b/app/api/actions/buy/const.ts
@@ -1,14 +1,41 @@
+export interface AssetMetadata {
+    name: string;
+    param: string;
+    image: string;
+    mint: string;
+}
+
 export const ATLAS: string = 'ATLASXmbPQxBUYbxPsV97usA3fPQYEqzQBUHgiFCUsXx';
 
-export const assets = [
+export const assets: AssetMetadata[] = [
     {
         name: 'Pearce X4',
         param: 'pearcex4',
+        image: 'https://shdw-drive.genesysgo.net/6CKtcXBouZ4mGAt4NzNcdW29rZCBMx3CTZtBn3zGmz6z/pearceX4.png',
         mint: '2iMhgB4pbdKvwJHVyitpvX5z1NBNypFonUgaSAt9dtDt',
+    },
+    {
+        name: 'Pearce X5',
+        param: 'pearcex5',
+        image: '',
+        mint: ''
+    },
+    {
+        name: 'Pearce R8',
+        param: 'pearcer8',
+        image: '',
+        mint: ''
+    },
+    {
+        name: 'Calico ATS Enforcer',
+        param: 'calicoatsenforcer',
+        image: '',
+        mint: ''
     },
     {
         name: 'Calico Maxhog',
         param: 'calicomaxhog',
+        image: 'https://shdw-drive.genesysgo.net/6CKtcXBouZ4mGAt4NzNcdW29rZCBMx3CTZtBn3zGmz6z/calicomaxhog%20(1).png',
         mint: 'GxpbUDxYYvxiUejHcAMzeV2rzdHf6KZZvT86ACrpFgXa',
     }
 ]

--- a/app/api/actions/buy/route.ts
+++ b/app/api/actions/buy/route.ts
@@ -8,7 +8,7 @@ import {
     getNftMint,
     validatedQueryParams
 } from '@/lib/chat/blinks/actions';
-import { assets, ATLAS } from '@/app/api/actions/buy/const';
+import { AssetMetadata, assets, ATLAS } from '@/app/api/actions/buy/const';
 
 export const dynamic = 'force-dynamic'
 
@@ -17,10 +17,10 @@ export const GET = async (req: Request) => {
         const requestURL = new URL(req.url);
         const { playerPubKey } = validatedQueryParams(requestURL);
         // Extract the asset parameter from the pathname
-        const assetParam = requestURL.searchParams.get("asset");
+        const getAssetParam = requestURL.searchParams.get("asset");
 
         // Find the matching asset
-        const matchingAsset = assets.find(asset => asset.param === assetParam);
+        const matchingAsset: AssetMetadata = assets.find(asset => asset.param === getAssetParam)!;
 
         const baseHref = new URL(`/api/buy?asset=${matchingAsset?.param}`, requestURL.origin).toString();
 
@@ -39,7 +39,7 @@ export const GET = async (req: Request) => {
 
         const payload: ActionGetResponse = {
             title: `Star Atlas: ${matchingAsset?.name} Market`,
-            icon: "https://staratlas.com/favicon.ico",
+            icon: `${matchingAsset?.image!}`,
             description: `Purchase an NFT from the Galactic Marketplace`,
             label: "FindOrdersForAsset",
             links: {


### PR DESCRIPTION
Needed a couple of assets to work with as I finish building this blink. Used shadow drive to store images because Blink requires a URL. Also maintains web3 aspect of the blink.